### PR TITLE
Fixed a bug that caused the WaitHelper::TIMEOUT to be 0 when WAIT_TIMEOU...

### DIFF
--- a/gem/lib/frank-cucumber/wait_helper.rb
+++ b/gem/lib/frank-cucumber/wait_helper.rb
@@ -11,7 +11,7 @@ module Cucumber
 #
 module WaitHelper
   # Default option for how long (in seconds) to keep checking before timing out the entire wait
-  TIMEOUT = ENV['WAIT_TIMEOUT'].to_i || 240
+  TIMEOUT = (ENV['WAIT_TIMEOUT'] || 240).to_i
   # How long to pause (in seconds) inbetween each spin through the assertion block
   POLL_SLEEP = 0.1
 


### PR DESCRIPTION
...T is not set.

The line
    `TIMEOUT = ENV['WAIT_TIMEOUT'].to_i || 240`
sets `TIMEOUT` to 0 if the `WAIT_TIMEOUT` is not set because `nil.to_i` is evaluated to 0 and the 240 is never assigned.
