### PR TITLE
HTTP server was being started multiple times

### DIFF
--- a/src/FrankLoader.m
+++ b/src/FrankLoader.m
@@ -25,13 +25,13 @@ BOOL frankLogEnabled = NO;
 @implementation FrankLoader
 
 + (void)applicationDidBecomeActive:(NSNotification *)notification{
-#if TARGET_OS_IPHONE
-    FrankServer *server = [[FrankServer alloc] initWithDefaultBundle];
-    [server startServer];
-    
-#else
     static dispatch_once_t frankDidBecomeActiveToken;
-    
+#if TARGET_OS_IPHONE
+    dispatch_once(&frankDidBecomeActiveToken, ^{
+        FrankServer *server = [[FrankServer alloc] initWithDefaultBundle];
+        [server startServer];
+    });
+#else
     dispatch_once(&frankDidBecomeActiveToken, ^{
         FrankServer *server = [[FrankServer alloc] initWithDefaultBundle];
         [server startServer];


### PR DESCRIPTION
When dismissing the location prompt at startup, [FrankLoader applicationDidBecomeActive:] can be called a second time resulting in a crash due to the default port being in use.
