### PR TITLE
Added FEX_dragWithDelayToX:y:duration: method to be able to specify drag...

### DIFF
--- a/src/UIView+PublicAutomation.m
+++ b/src/UIView+PublicAutomation.m
@@ -285,4 +285,9 @@ NSString * formatCGPointVal(NSValue *val) {
     return YES;
 }
 
+- (BOOL)FEX_dragWithInitialDelayToX:(CGFloat)x y:(CGFloat)y duration:(NSTimeInterval)duration {
+    [UIAutomationBridge dragViewWithInitialDelay:self toPoint:CGPointMake(x,y) duration:duration];
+    return YES;
+}
+
 @end


### PR DESCRIPTION
... duration in tests. This should fix view swiping if drag delay is bigger.