### PR TITLE
Improve iOS 9 support

### DIFF
--- a/src/FrankLoader.m
+++ b/src/FrankLoader.m
@@ -86,6 +86,26 @@ BOOL frankLogEnabled = NO;
                                              selector:@selector(applicationDidBecomeActive:)
                                                  name:notificationName
                                                object:nil];
+
+#if TARGET_OS_IPHONE
+    NSArray *iOSVersionComponents = [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."];
+    int majorVersion = [[iOSVersionComponents objectAtIndex:0] intValue];
+
+    if (majorVersion >= 9) 
+    { 
+        // iOS9 is installed. The UIApplicationDidBecomeActiveNotification may have been fired *before* 
+        // this code is called.
+        // See also:
+        // http://stackoverflow.com/questions/31785878/ios-9-uiapplicationdidbecomeactivenotification-callback-not-called
+
+        // Call applicationDidBecomeActive: after 0.5 second. 
+        // Delay execution of my block for 10 seconds.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 500 * USEC_PER_SEC), dispatch_get_main_queue(), ^{
+            NSLog(@"Forcefully invoking applicationDidBecomeActive");
+            [FrankLoader applicationDidBecomeActive:nil];
+        });
+    }
+#endif
 }
 
 @end


### PR DESCRIPTION
Fixes two issues that prevent Frank from initializing correctly on iOS 9:

* The AX Inspector needs to be enabled (as seen in [KIF](https://github.com/kif-framework/KIF/blob/master/Classes/KIFAccessibilityEnabler.m) and [EarlGrey](https://github.com/google/EarlGrey/blob/master/EarlGrey/EarlGrey.m). If the AX inspector is not enabled, the accessibility properties (such as `accessibilityLabel`) are not populated and selectors such as `marked` don't work as expected
* Some additional logging in the `load` method.
* The `UIApplicationDidBecomeActiveNotification` notification is not always sent on iOS 9 - as also documented [on StackOverflow](http://stackoverflow.com/questions/31785878/ios-9-uiapplicationdidbecomeactivenotification-callback-not-called)