### PR TITLE
Remove pry-debugger since debugger is not supported for ruby 2.x

### DIFF
--- a/gem/frank-cucumber.gemspec
+++ b/gem/frank-cucumber.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency( "rr" )
   s.add_development_dependency( "yard" )
   s.add_development_dependency( "pry" )
-  s.add_development_dependency( "pry-debugger" )
 end


### PR DESCRIPTION
Under ruby 2.X, running 'bundle install' fails because debugger is not supported under ruby 2.X. Pry-debugger depends on debugger. Remove it since it is not very important for developers. 